### PR TITLE
Update "Popular Misskey Servers"

### DIFF
--- a/apps/mobile/components/screens/profile/stack/onboard/data/server-meta.ts
+++ b/apps/mobile/components/screens/profile/stack/onboard/data/server-meta.ts
@@ -15,10 +15,9 @@
 
 export const POPULAR_MISSKEY_SERVERS = [
 	{ value: 'misskey.io', label: '👑 🇯🇵 misskey.io' },
-	{ value: 'misskey.dev', label: 'misskey.dev' },
 	{ value: 'misskey.id', label: ' 🇮🇩 misskey.id' },
 	{ value: 'misskey.design', label: 'misskey.design' },
-	{ value: 'trpger.us', label: '🇯🇵 trpger.us' },
+	{ value: 'takusuki.com', label: '🇯🇵 takusuki.com' },
 	{ value: 'sushi.ski', label: '🇯🇵 sushi.ski' },
 	{ value: 'nijimiss.moe', label: '🇯🇵 nijimiss.moe' },
 ];


### PR DESCRIPTION
### 🤔 Description

Misskeyサーバーの入力候補を次の様に更新しました

- misskey.devを削除
  - misskeyのバージョンがv11と古く、MiAuthに対応していないためログインができないため
- trpger.usをtakusuki.comに変更
  - サーバーの事情によりドメインが変更されたため

### 📝 License Disclaimer

This project accepts contributions under MIT license only.

This lets me add and bundle purchased/licensed art assets outside the 
codebase, while benefitting from sublicensed copyleft protection as an indie 
publisher.

I value your hard work. So, I want to make sure you are okay with this arrangement 😄

- [x] I allow my contributions to be licensed under the MIT license.